### PR TITLE
Add SQL backup deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy SQL backup job
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy backup job to server
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: root
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          script: |
+            set -eu
+
+            cd /opt/akatsuki/sql-backup-job
+            git fetch origin master
+            git checkout -B master origin/master
+
+            python3 -m venv venv
+            ./venv/bin/python -m pip install --upgrade pip
+            ./venv/bin/python -m pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- add a GitHub Actions deploy workflow for `sql-backup-job`
- on pushes to `master`, SSH to the production server and update `/opt/akatsuki/sql-backup-job` from `origin/master`
- create/update a repo-local Python virtualenv and install `requirements.txt`

## Verification
- `pre-commit run --files .github/workflows/deploy.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy.yml")'`
- `git diff --check`

## Rollout
Merge this before enabling the retention cron in `hetzner-infra`, so `/opt/akatsuki/sql-backup-job` has the current retention script and virtualenv available.
