### PR TITLE
Ignore local virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /export
+venv/
 .env
 .vscode/


### PR DESCRIPTION
## Summary
- ignore the repo-local `venv/` created by the deploy workflow
- keep the deployed checkout clean after dependency installation

## Verification
- `pre-commit run --files .gitignore`
- `git diff --check`
