### PR TITLE
Tighten SQL backup retention policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /export
 venv/
+__pycache__/
 .env
 .vscode/

--- a/backup_retention_policy.py
+++ b/backup_retention_policy.py
@@ -4,12 +4,16 @@ A script to delete old backups from wasabi S3 based on a retention policy.
 
 Policy definition:
 - Keep all backups that are less than 50 days old
-- Keep all backups that are either on the midpoint of the month or the first day of the month
+- Keep one backup per half-month from 50 to 180 days old
+- Keep one backup per month from 180 to 365 days old
+- Keep one backup per quarter after 365 days
 - Delete all other backups
 """
 from __future__ import annotations
 
+import json
 import os.path
+import urllib.request
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -19,9 +23,14 @@ import dotenv
 
 dotenv.load_dotenv()
 
+DAILY_RETENTION_DAYS = 50
+SEMI_MONTHLY_RETENTION_DAYS = 180
+MONTHLY_RETENTION_DAYS = 365
+BYTES_PER_GIB = 1024**3
 
-def should_keep_backup(backup_filepath: str) -> bool:
-    directory, _ = os.path.split(backup_filepath)
+
+def parse_backup_time(backup_filepath: str) -> datetime:
+    directory = backup_filepath.rstrip("/")
     try:
         # New: 'db-backups/2024-02-01T04:08Z'
         backup_time = datetime.strptime(
@@ -38,16 +47,115 @@ def should_keep_backup(backup_filepath: str) -> bool:
         # Backups were previously named in EST
         tzinfo = timezone(timedelta(hours=-4))
 
-    backup_time = backup_time.replace(tzinfo=tzinfo)
-    current_time = datetime.now(tz=tzinfo)
+    return backup_time.replace(tzinfo=tzinfo)
 
-    if (current_time - backup_time).days < 50:
-        return True
 
-    if backup_time.day == 15 or backup_time.day == 1:
-        return True
+def get_retention_bucket(
+    backup_time: datetime,
+    current_time: datetime,
+) -> tuple[str, int, int, int] | None:
+    age_days = (current_time - backup_time.astimezone(current_time.tzinfo)).days
 
-    return False
+    if age_days < DAILY_RETENTION_DAYS:
+        return None
+
+    if age_days < SEMI_MONTHLY_RETENTION_DAYS:
+        half_month = 1 if backup_time.day <= 15 else 2
+        return ("semi-month", backup_time.year, backup_time.month, half_month)
+
+    if age_days < MONTHLY_RETENTION_DAYS:
+        return ("month", backup_time.year, backup_time.month, 0)
+
+    quarter = (backup_time.month - 1) // 3 + 1
+    return ("quarter", backup_time.year, quarter, 0)
+
+
+def select_backups_to_keep(
+    directories: list[str],
+    current_time: datetime | None = None,
+) -> set[str]:
+    if current_time is None:
+        current_time = datetime.now(tz=timezone.utc)
+    else:
+        current_time = current_time.astimezone(timezone.utc)
+
+    kept = set[str]()
+    bucketed_backups = dict[tuple[str, int, int, int], tuple[datetime, str]]()
+    for directory in directories:
+        backup_time = parse_backup_time(directory)
+        bucket = get_retention_bucket(backup_time, current_time)
+        if bucket is None:
+            kept.add(directory)
+            continue
+
+        existing = bucketed_backups.get(bucket)
+        if existing is None or backup_time < existing[0]:
+            bucketed_backups[bucket] = (backup_time, directory)
+
+    kept.update(directory for _, directory in bucketed_backups.values())
+    return kept
+
+
+def list_backup_directories(s3) -> list[str]:
+    paginator = s3.get_paginator("list_objects_v2")
+    directories = []
+    for page in paginator.paginate(
+        Bucket=os.environ["S3_BUCKET_NAME"],
+        Prefix="db-backups/",
+        Delimiter="/",
+    ):
+        directories.extend(
+            obj["Prefix"] for obj in page.get("CommonPrefixes", []) if "Prefix" in obj
+        )
+
+    return directories
+
+
+def list_backup_objects(s3, directory: str) -> list[dict]:
+    paginator = s3.get_paginator("list_objects_v2")
+    objects = []
+    for page in paginator.paginate(
+        Bucket=os.environ["S3_BUCKET_NAME"],
+        Prefix=directory,
+    ):
+        objects.extend(
+            obj for obj in page.get("Contents", []) if "Key" in obj and "Size" in obj
+        )
+
+    return objects
+
+
+def delete_objects(s3, objects: list[dict]) -> None:
+    for index in range(0, len(objects), 1000):
+        chunk = objects[index : index + 1000]
+        s3.delete_objects(
+            Delete={"Objects": [{"Key": obj["Key"]} for obj in chunk]},
+            Bucket=os.environ["S3_BUCKET_NAME"],
+        )
+
+
+def format_gib(byte_count: float) -> str:
+    return f"{byte_count / BYTES_PER_GIB:.2f} GB"
+
+
+def send_discord_notification(content: str) -> None:
+    webhook_url = os.environ.get("DISCORD_WEBHOOK_URL")
+    if not webhook_url:
+        return
+
+    payload = json.dumps({"username": "Akatsuki", "content": content}).encode()
+    request = urllib.request.Request(
+        webhook_url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=10):
+            pass
+    except (OSError, TimeoutError, ValueError) as exc:
+        print(f"Failed to send Discord notification: {exc}")
 
 
 def main() -> int:
@@ -59,52 +167,35 @@ def main() -> int:
         region_name=os.environ["AWS_DEFAULT_REGION"],
     )
 
-    response = s3.list_objects_v2(
-        Bucket=os.environ["S3_BUCKET_NAME"],
-        Prefix="db-backups/",
-        Delimiter="/",
-    )
-    directories = [
-        obj["Prefix"] for obj in response.get("CommonPrefixes", []) if "Prefix" in obj
-    ]
+    directories = list_backup_directories(s3)
 
     # Figure out which backups to keep and delete
-    kept = set[str]()
-    deleted = set[str]()
-    for directory in directories:
-        if should_keep_backup(directory):
-            kept.add(directory)
-        else:
-            deleted.add(directory)
+    kept = select_backups_to_keep(directories)
+    deleted = set(directories) - kept
 
     # Delete the backups that should be deleted
     total_bytes_deleted = 0.0
-    for directory in deleted:
+    for directory in sorted(deleted):
         bucket_bytes_deleted = 0.0
-        response = s3.list_objects_v2(
-            Bucket=os.environ["S3_BUCKET_NAME"],
-            Prefix=directory,
-        )
-        objects = [
-            obj
-            for obj in response.get("Contents", [])
-            if "Key" in obj and "Size" in obj
-        ]
+        objects = list_backup_objects(s3, directory)
         bucket_bytes_deleted += sum(obj["Size"] for obj in objects)
-        s3.delete_objects(
-            Delete={"Objects": [{"Key": obj["Key"]} for obj in objects]},
-            Bucket=os.environ["S3_BUCKET_NAME"],
-        )
+        delete_objects(s3, objects)
 
         print(
-            f"Deleted {directory} ({len(objects)} objects, {bucket_bytes_deleted / 1024 ** 3:.2f} GB)",
+            f"Deleted {directory} ({len(objects)} objects, {format_gib(bucket_bytes_deleted)})",
         )
         total_bytes_deleted += bucket_bytes_deleted
 
     # Display stats
     print(f"Kept {len(kept)} backups")
-    print(f"Deleted {len(deleted)} backups ({total_bytes_deleted / 1024 ** 3:.2f} GB)")
+    print(f"Deleted {len(deleted)} backups ({format_gib(total_bytes_deleted)})")
     print(f"Total backups: {len(directories)}")
+
+    send_discord_notification(
+        "SQL backup retention completed - "
+        f"deleted {len(deleted)} backups ({format_gib(total_bytes_deleted)} reclaimed), "
+        f"kept {len(kept)} of {len(directories)} backups.",
+    )
     return 0
 
 

--- a/test_backup_retention_policy.py
+++ b/test_backup_retention_policy.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from datetime import datetime
+from datetime import timezone
+from unittest import mock
+
+import backup_retention_policy
+
+
+class BackupRetentionPolicyTest(unittest.TestCase):
+    def test_selects_tiered_backup_buckets(self) -> None:
+        current_time = datetime(2026, 8, 3, tzinfo=timezone.utc)
+        directories = [
+            "db-backups/2026-06-20T04:18Z/",
+            "db-backups/2026-05-10T04:18Z/",
+            "db-backups/2026-05-12T04:18Z/",
+            "db-backups/2026-05-20T04:18Z/",
+            "db-backups/2026-01-01T04:18Z/",
+            "db-backups/2026-01-15T04:18Z/",
+            "db-backups/2025-03-01T04:18Z/",
+            "db-backups/2025-04-01T04:18Z/",
+            "db-backups/2025-06-01T04:18Z/",
+        ]
+
+        kept = backup_retention_policy.select_backups_to_keep(
+            directories,
+            current_time=current_time,
+        )
+
+        self.assertEqual(
+            kept,
+            {
+                "db-backups/2026-06-20T04:18Z/",
+                "db-backups/2026-05-10T04:18Z/",
+                "db-backups/2026-05-20T04:18Z/",
+                "db-backups/2026-01-01T04:18Z/",
+                "db-backups/2025-03-01T04:18Z/",
+                "db-backups/2025-04-01T04:18Z/",
+            },
+        )
+
+    def test_send_discord_notification_uses_backup_webhook(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"DISCORD_WEBHOOK_URL": "https://discord.example/webhook"},
+        ):
+            with mock.patch("urllib.request.urlopen") as urlopen:
+                backup_retention_policy.send_discord_notification("hello")
+
+        request = urlopen.call_args.args[0]
+        self.assertEqual(request.full_url, "https://discord.example/webhook")
+        self.assertEqual(request.get_method(), "POST")
+        self.assertEqual(request.headers["Content-type"], "application/json")
+        self.assertEqual(
+            json.loads(request.data.decode()),
+            {"username": "Akatsuki", "content": "hello"},
+        )
+
+    def test_delete_objects_uses_s3_bucket_name(self) -> None:
+        s3 = mock.Mock()
+        objects = [{"Key": "one"}, {"Key": "two"}]
+
+        with mock.patch.dict(os.environ, {"S3_BUCKET_NAME": "akatsuki.pw"}):
+            backup_retention_policy.delete_objects(s3, objects)
+
+        s3.delete_objects.assert_called_once_with(
+            Delete={"Objects": [{"Key": "one"}, {"Key": "two"}]},
+            Bucket="akatsuki.pw",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- change retention from 50 daily + twice-monthly forever to tiered retention:
  - keep all backups under 50 days old
  - keep one backup per half-month from 50 to 180 days old
  - keep one backup per month from 180 to 365 days old
  - keep one backup per quarter after 365 days
- choose the earliest backup in each bucket, so retention does not depend on an exact 1st/15th backup existing
- send the retention reclaim summary to the same `DISCORD_WEBHOOK_URL` used by the backup job
- add unit coverage for retention bucketing, Discord webhook payloads, and S3 delete bucket usage

## Live dry-run estimate
Against the current `db-backups/` listing, this policy would keep 70 backups / 591.16 GB and delete 39 backups / 204.60 GB.

## Verification
- ./venv/bin/python -m unittest -v
- pre-commit run --files backup_retention_policy.py test_backup_retention_policy.py .gitignore
- git diff --check
- read-only live bucket simulation
