### PR TITLE
Add retention Discord User-Agent

### DIFF
--- a/backup_retention_policy.py
+++ b/backup_retention_policy.py
@@ -147,7 +147,10 @@ def send_discord_notification(content: str) -> None:
     request = urllib.request.Request(
         webhook_url,
         data=payload,
-        headers={"Content-Type": "application/json"},
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "Akatsuki SQL Backup Retention",
+        },
         method="POST",
     )
 

--- a/test_backup_retention_policy.py
+++ b/test_backup_retention_policy.py
@@ -55,6 +55,10 @@ class BackupRetentionPolicyTest(unittest.TestCase):
         self.assertEqual(request.get_method(), "POST")
         self.assertEqual(request.headers["Content-type"], "application/json")
         self.assertEqual(
+            request.headers["User-agent"],
+            "Akatsuki SQL Backup Retention",
+        )
+        self.assertEqual(
             json.loads(request.data.decode()),
             {"username": "Akatsuki", "content": "hello"},
         )


### PR DESCRIPTION
## Summary
- add an explicit User-Agent header to the retention Discord webhook request
- assert the header in the webhook unit test

## Context
The manual retention run succeeded, but Discord returned `HTTP Error 403: Forbidden` for the Python urllib request. The backup job uses curl, which sends a User-Agent by default; this makes the retention webhook request behave similarly.

## Verification
- ./venv/bin/python -m unittest -v
- pre-commit run --files backup_retention_policy.py test_backup_retention_policy.py
- git diff --check
